### PR TITLE
fix: added commas in `suggests` and `depends`  fields in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,10 +10,10 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 Suggests: 
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
     roxygen2
 Config/testthat/edition: 3
 Depends: 
-    R (>= 2.10)
+    R (>= 2.10),
     dplyr
 LazyData: true


### PR DESCRIPTION
## Issue

Closes #38

## Description

Added missing commas in `suggests` and `depends`  fields in DESCRIPTION

## How to test

Run `devtools::check()`

## Contributor checklist

- [ ] Package version is incremented
