### PR TITLE
title field should be in title case

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: REXoplanets
 Title: Creates Interface with NASA Exoplanets API
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(
     person("Jakub", "Kołomański", email = "xqubula@gmail.com", role = c("cre", "aut")),
     person("Mateusz", "Kołomański", email = "m.kolomanski.biosoftware@gmail.com", role = "aut"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: REXoplanets
-Title: Creates interface with NASA exoplanets API
+Title: Creates Interface with NASA Exoplanets API
 Version: 0.1.0
 Authors@R: c(
     person("Jakub", "Kołomański", email = "xqubula@gmail.com", role = c("cre", "aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# [REXoplanets 0.1.1](https://github.com/JKolomanski/REXoplanets/releases/tag/v0.1.1)
+* Change the `Title` field to Title Case to meet CRAN requirements
+
 # [REXoplanets 0.1.0](https://github.com/JKolomanski/REXoplanets/releases/tag/v0.1.0)
 * Initial release of **REXoplanets** package
 * Added API interface for fetching exoplanet data

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 # [REXoplanets 0.1.1](https://github.com/JKolomanski/REXoplanets/releases/tag/v0.1.1)
-* Change the `Title` field to Title Case to meet CRAN requirements
+* Change the `Title` field  in the `DESCRIPTION` file to Title Case to meet CRAN requirements
 
 # [REXoplanets 0.1.0](https://github.com/JKolomanski/REXoplanets/releases/tag/v0.1.0)
 * Initial release of **REXoplanets** package


### PR DESCRIPTION
## Issue

Closes #119 

## Description

Changes the `title` field in `DESCRIPTION` to be in Title Case, following CRAn requirements

## How to test

open `DESCRIPTION`

## Contributor checklist

- [x] Package version is incremented
