### PR TITLE
fix inconsistensies with cran guidelines

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: REXoplanets
 Title: Creates Interface with NASA 'Exoplanets Archive API'
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: c(
     person("Jakub", "Kołomański", email = "xqubula@gmail.com", role = c("cre", "aut")),
     person("Mateusz", "Kołomański", email = "m.kolomanski.biosoftware@gmail.com", role = "aut"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,9 +4,9 @@ Version: 0.1.1
 Authors@R: c(
     person("Jakub", "Kołomański", email = "xqubula@gmail.com", role = c("cre", "aut")),
     person("Mateusz", "Kołomański", email = "m.kolomanski.biosoftware@gmail.com", role = "aut"))
-Description: Provides a user-friendly interface to NASA 'Exoplanets Archive API', 
-    enabling retrieval and analysis of exoplanetary and stellar data. Includes functions for querying, 
-    filtering, summarizing, and computing derived parameters from the 'Exoplanets' catalog. 
+Description: Provides a user-friendly interface to NASA 'Exoplanets Archive API'
+    <https://exoplanetarchive.ipac.caltech.edu/>, enabling retrieval and analysis of exoplanetary and stellar data. 
+    Includes functions for querying, filtering, summarizing, and computing derived parameters from the 'Exoplanets' catalog. 
 License: MIT + file LICENSE
 Depends: 
     R (>= 4.1)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,6 @@ Suggests:
     roxygen2,
     lintr,
     devtools,
-    pak,
     spelling,
     shiny,
     shinyjs,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: REXoplanets
-Title: Creates Interface with NASA 'Exoplanets API'
+Title: Creates Interface with NASA 'Exoplanets Archive API'
 Version: 0.1.1
 Authors@R: c(
     person("Jakub", "Kołomański", email = "xqubula@gmail.com", role = c("cre", "aut")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,12 @@
 Package: REXoplanets
-Title: Creates Interface with NASA Exoplanets API
+Title: Creates Interface with NASA 'Exoplanets API'
 Version: 0.1.1
 Authors@R: c(
     person("Jakub", "Kołomański", email = "xqubula@gmail.com", role = c("cre", "aut")),
     person("Mateusz", "Kołomański", email = "m.kolomanski.biosoftware@gmail.com", role = "aut"))
-Description: Provides a user-friendly interface to the NASA Exoplanets Archive API, 
+Description: Provides a user-friendly interface to NASA 'Exoplanets Archive API', 
     enabling retrieval and analysis of exoplanetary and stellar data. Includes functions for querying, 
-    filtering, summarizing, and computing derived parameters from the Exoplanets catalog. 
+    filtering, summarizing, and computing derived parameters from the 'Exoplanets' catalog. 
 License: MIT + file LICENSE
 Depends: 
     R (>= 4.1)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# [REXoplanets 0.1.2](https://github.com/JKolomanski/REXoplanets/releases/tag/v0.1.2)
+  * Use single quotes around package names, software names, and API names in `Title` and `Description` fields of `DESCRIPTION`
+  * Add web reference for the NASA Exoplanets API in `DESCRIPTION`
+  * Replace `\dontrun{}` with `\donttest{}` in examples
+  * Remove automatic download of external packages in `app.R` and instead show a message suggesting installation of missing dependencies
+
 # [REXoplanets 0.1.1](https://github.com/JKolomanski/REXoplanets/releases/tag/v0.1.1)
 * Change the `Title` field  in the `DESCRIPTION` file to Title Case to meet CRAN requirements
 

--- a/R/app.R
+++ b/R/app.R
@@ -61,7 +61,7 @@ check_app_dependencies = function() {
     stop(paste0(
       "The following packages are required for shiny application, but are missing:\n",
       paste0("    - ", missing_packages, collapse = "\n"), "\n",
-      "Install missing packages to proceed"
+      "Install missing packages to run the application."
     ))
   }
 }

--- a/R/app.R
+++ b/R/app.R
@@ -61,7 +61,7 @@ check_app_dependencies = function() {
     stop(paste0(
       "The following packages are required for shiny application, but are missing:\n",
       paste0("    - ", missing_packages, collapse = "\n"), "\n",
-      "Install missing packages to proceed: "
+      "Install missing packages to proceed"
     ))
   }
 }

--- a/R/app.R
+++ b/R/app.R
@@ -58,45 +58,10 @@ check_app_dependencies = function() {
   missing_packages = purrr::keep(APP_PACKAGES, \(dep) !requireNamespace(dep, quietly = TRUE))
 
   if (length(missing_packages) > 0) {
-    msg = paste0(
+    stop(paste0(
       "The following packages are required for shiny application, but are missing:\n",
       paste0("    - ", missing_packages, collapse = "\n"), "\n",
-      "Do you want to install them now? (yes/no): "
-    )
-
-    proceed = readline(msg)
-    if (!assert_valid_answer(proceed)) {
-      proceed = readline("Please answer with 'yes' or 'no': ")
-    }
-    if (!assert_valid_answer(proceed)) {
-      stop("Unknown answer, aborting installation.")
-    }
-
-    if (assert_no(proceed)) {
-      stop(
-        "Shiny application cannot run without following packages:\n",
-        paste0("    - ", missing_packages, collapse = "\n"), "\n",
-        "Aborting application startup."
-      )
-    }
-
-    if (!requireNamespace("pak", silently = TRUE)) {
-      install.packages("pak")
-      requireNamespace("pak", quietly = TRUE)
-    }
-
-    pak::pak(missing_packages)
+      "Install missing packages to proceed: "
+    ))
   }
-}
-
-#' @keywords internal
-assert_valid_answer = function(answer) {
-  valid_answers = c("yes", "no", "y", "n")
-  tolower(answer) %in% valid_answers
-}
-
-#' @keywords internal
-assert_no = function(answer) {
-  no_answers = c("no", "n")
-  tolower(answer) %in% no_answers
 }

--- a/R/fetch_table.R
+++ b/R/fetch_table.R
@@ -33,7 +33,7 @@
 #' @importFrom logger log_info log_success log_error log_debug log_trace
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #'  # All entries from Stellar Hosts table
 #'  fetch_table("stellarhosts")
 #'  # Entries from Planetary Systems table where planetary mass > 3 times the earth mass

--- a/R/scatterplot_esi.R
+++ b/R/scatterplot_esi.R
@@ -21,7 +21,7 @@
 #' @examples
 #' \donttest{
 #' closest_50_exoplanets |>
-#'   dplyr::mutate(esi = calculate_esi(pl_rade, pl_insol)) |>
+#'   dplyr::mutate(esi = calculate_esi(radius = pl_rade, flux = pl_insol)) |>
 #'   scatterplot_esi()
 #' }
 #' @export

--- a/R/scatterplot_esi.R
+++ b/R/scatterplot_esi.R
@@ -19,7 +19,7 @@
 #' @importFrom checkmate assert_names assert_data_frame assert_numeric
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' closest_50_exoplanets |>
 #'   dplyr::mutate(esi = calculate_esi(pl_rade, pl_insol)) |>
 #'   scatterplot_esi()

--- a/man/fetch_table.Rd
+++ b/man/fetch_table.Rd
@@ -41,7 +41,7 @@ and returns it as a data frame or a named list.
 You can optionally specify \code{WHERE} ADQL clause to filter rows based on conditions.
 }
 \examples{
-\dontrun{
+\donttest{
  # All entries from Stellar Hosts table
  fetch_table("stellarhosts")
  # Entries from Planetary Systems table where planetary mass > 3 times the earth mass

--- a/man/scatterplot_esi.Rd
+++ b/man/scatterplot_esi.Rd
@@ -28,9 +28,9 @@ colored by the Earth Similarity Index (ESI).
 Dashed lines at (1,1) indicate Earth's reference values for stellar flux and radius.
 }
 \examples{
-\dontrun{
+\donttest{
 closest_50_exoplanets |>
-  dplyr::mutate(esi = calculate_esi(pl_rade, pl_insol)) |>
+  dplyr::mutate(esi = calculate_esi(radius = pl_rade, flux = pl_insol)) |>
   scatterplot_esi()
 }
 }


### PR DESCRIPTION
## Issue

Closes #123

## Description

Fixes several issues with CRAN guidelines:
- Use single quotes around package names, software names, and API names in *Title* and *Description* fields of `DESCRIPTION`.  
- Add a web reference for the NASA Exoplanets API in `DESCRIPTION`. 
- Replace `\dontrun{}` with `\donttest{}` in examples.
- Remove any code that dowloads external packages in `app.R`. Instead, show the user a message suggesting to install missing dependencies.

## How to test

Run `app()` with missing dependencies

## Contributor checklist

- [x] Code passes lintr checks
- [x] Code passes all unit tests
- [x] Package version is incremented
